### PR TITLE
Add Pod::Weaver::PluginBundle::Author::PERLANCAR to requirements

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.55    2017-02-09 (PERLANCAR)
+
+	- Add plugin: CopyrightYearFromGit.
+
+
 0.54    2016-12-28 (PERLANCAR)
 
 	- Add plugin: PERLANCAR::BeforeBuild to e.g. make sure that

--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,4 @@
-version=0.54
+version=0.55
 
 name=Dist-Zilla-PluginBundle-Author-PERLANCAR
 

--- a/dist.ini
+++ b/dist.ini
@@ -24,6 +24,8 @@ Dist::Zilla::Plugin::CheckChangeLog=0
 ;!lint_prereqs assume-used "undetected by scan_prereqs"
 Dist::Zilla::Plugin::CheckMetaResources=0
 ;!lint_prereqs assume-used "undetected by scan_prereqs"
+Dist::Zilla::Plugin::CopyrightYearFromGit=0
+;!lint_prereqs assume-used "undetected by scan_prereqs"
 Dist::Zilla::Plugin::EnsureSQLSchemaVersionedTest=0
 ;!lint_prereqs assume-used "convenience, often required"
 Dist::Zilla::Plugin::Extras=0

--- a/dist.ini
+++ b/dist.ini
@@ -82,6 +82,7 @@ Module::Version=0
 Moose=0
 ;!lint_prereqs assume-used "pull for convenience, not pulled by DZP:PodCoverageTests"
 Pod::Coverage::TrustPod=0
+Pod::Weaver::PluginBundle::Author::PERLANCAR=0
 ;!lint_prereqs assume-used "pull for convenience, not pulled by DZP:PodSyntaxTests"
 Test::Pod=0
 ;!lint_prereqs assume-used "pull for convenience, not pulled by DZP:PodCoverageTests"

--- a/lib/Dist/Zilla/PluginBundle/Author/PERLANCAR.pm
+++ b/lib/Dist/Zilla/PluginBundle/Author/PERLANCAR.pm
@@ -25,6 +25,7 @@ sub configure {
         'PERLANCAR::MetaResources',
         'CheckChangeLog',
         'CheckMetaResources',
+        'CopyrightYearFromGit',
         'IfBuilt',
         'MetaJSON',
         'MetaConfig',


### PR DESCRIPTION
The `weaver.ini` file in this plugin uses the `@Author::PERLANCAR` plugin bundle for Pod::Weaver, but that is not marked as a requirement. This meant that one could install the Dist::Zilla plugin and still not have a usable version, which would result in odd errors when using `dzil` to process some of the packages that used this author plugin bundle.

This patch solves this by marking the pod weaver plugin as a requirement in `dist.ini`.

Note: this patch is only for b5daf6e, but branches off from [tag 0.55](https://github.com/perlancar/perl-Dist-Zilla-PluginBundle-Author-PERLANCAR/releases/tag/v0.55) (3567035) instead of from HEAD, since HEAD seems to be running behind. Will happily change this if it is not preferred.